### PR TITLE
Fix path comment case in signalcrypto.js

### DIFF
--- a/web-chat/src/services/signalcrypto.js
+++ b/web-chat/src/services/signalcrypto.js
@@ -1,4 +1,4 @@
-// web-chat/src/services/signalCrypto.js
+// web-chat/src/services/signalcrypto.js
 
 import * as libsignal from 'libsignal';
 


### PR DESCRIPTION
## Summary
- correct the path comment to match filename

## Testing
- `git status --short`