### PR TITLE
Serve static root files

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -15,11 +15,15 @@ const PORT = process.env.PORT || 4000;
 // Middleware
 app.use(cors());
 app.use(express.json());
-app.use(express.static(path.resolve(__dirname, '..')));
+
+// Serve static files from the project root
+const rootPath = path.join(__dirname, '..');
+app.use(express.static(rootPath));
 
 // Routes
 app.get('/', (req, res) => {
-  res.sendFile(path.resolve(__dirname, '..', 'index.html'));
+  // Send the welcome page when visiting the root URL
+  res.sendFile(path.join(rootPath, 'index.html'));
 });
 app.use('/api/auth', authRoutes);
 app.use('/api/messages', messageRoutes);


### PR DESCRIPTION
## Summary
- use `express.static` to serve files from the project root
- send `index.html` on `/`

## Testing
- `npm start` *(fails: Cannot find module 'express')*